### PR TITLE
Improved view before launching and removed "test" processes from view

### DIFF
--- a/src/elements/Home/Berga.tsx
+++ b/src/elements/Home/Berga.tsx
@@ -45,22 +45,24 @@ const Berga = () => (
       </Text>
     </Box>
     <Box>
-      <Text textAlign='center' fontWeight='bold' mb={5}>
+      <Text textAlign='center' fontWeight='bold' mb={5} mt='30px' fontSize='20px'>
         LA VOTACIÓ COMENÇARÀ EL DIJOUS 13 DE FEBRER A LES 9:30
       </Text>
-      <Text alignSelf='start' mb={10}>
-        <strong>Seleccioneu</strong> una opció depenent de la teva edat
-      </Text>
-      <Flex gap={5} flexDirection={{ base: 'column', md: 'row' }}>
-        <ProcessLink id='b31dff61814dd60812a70bb63b3693846873c371c2463472a4d3020800000000'>
-          <Text fontSize='18px'>Accedeix a la votació Juvenil</Text>
-          <Text>12 - 15 anys</Text>
-        </ProcessLink>
-        <ProcessLink id='b31dff61814dd60812a70bb63b3693846873c371c2463472a4d3020000000001'>
-          <Text fontSize='18px'>Accedeix a la votació General</Text>
-          <Text>+16 anys</Text>
-        </ProcessLink>
-      </Flex>
+      <Box display='none'>
+        <Text alignSelf='start' mb={10}>
+          <strong>Seleccioneu</strong> una opció depenent de la teva edat
+        </Text>
+        <Flex gap={5} flexDirection={{ base: 'column', md: 'row' }}>
+          <ProcessLink id='b31dff61814dd60812a70bb63b3693846873c371c2463472a4d3020800000000'>
+            <Text fontSize='18px'>Accedeix a la votació Juvenil</Text>
+            <Text>12 - 15 anys</Text>
+          </ProcessLink>
+          <ProcessLink id='b31dff61814dd60812a70bb63b3693846873c371c2463472a4d3020000000001'>
+            <Text fontSize='18px'>Accedeix a la votació General</Text>
+            <Text>+16 anys</Text>
+          </ProcessLink>
+        </Flex>
+      </Box>
     </Box>
     <Text>
       Per poder accedir a la votació, us demanarem el vostre número de DNI (Document Nacional d'Identitat) i data de

--- a/src/elements/Home/Berga.tsx
+++ b/src/elements/Home/Berga.tsx
@@ -4,6 +4,8 @@ import { Link as ReactRouterLink } from 'react-router-dom'
 import VocdoniLogo from '~components/Layout/Logo'
 import bergaImg from '/assets/berga/logo.png'
 
+const votingProcessIds = [];
+
 const Berga = () => (
   <Flex flexDirection='column' gap={10} maxW='900px' mx='auto' p={5} minH='100vh'>
     <Image src={bergaImg} width='300px' alt='ajuntament berga escut' mx='auto' />
@@ -48,21 +50,23 @@ const Berga = () => (
       <Text textAlign='center' fontWeight='bold' mb={5} mt='30px' fontSize='20px'>
         LA VOTACIÓ COMENÇARÀ EL DIJOUS 13 DE FEBRER A LES 9:30
       </Text>
-      <Box display='none'>
-        <Text alignSelf='start' mb={10}>
-          <strong>Seleccioneu</strong> una opció depenent de la teva edat
-        </Text>
-        <Flex gap={5} flexDirection={{ base: 'column', md: 'row' }}>
-          <ProcessLink id='b31dff61814dd60812a70bb63b3693846873c371c2463472a4d3020800000000'>
-            <Text fontSize='18px'>Accedeix a la votació Juvenil</Text>
-            <Text>12 - 15 anys</Text>
-          </ProcessLink>
-          <ProcessLink id='b31dff61814dd60812a70bb63b3693846873c371c2463472a4d3020000000001'>
-            <Text fontSize='18px'>Accedeix a la votació General</Text>
-            <Text>+16 anys</Text>
-          </ProcessLink>
-        </Flex>
-      </Box>
+      {votingProcessIds.length > 0 && (
+        <Box>
+          <Text alignSelf='start' mb={10}>
+            <strong>Seleccioneu</strong> una opció depenent de la teva edat
+          </Text>
+          <Flex gap={5} flexDirection={{ base: 'column', md: 'row' }}>
+            <ProcessLink id={votingProcessIds[0]}>
+              <Text fontSize='18px'>Accedeix a la votació Juvenil</Text>
+              <Text>12 - 15 anys</Text>
+            </ProcessLink>
+            <ProcessLink id={votingProcessIds[1]}>
+              <Text fontSize='18px'>Accedeix a la votació General</Text>
+              <Text>+16 anys</Text>
+            </ProcessLink>
+          </Flex>
+        </Box>
+      )}
     </Box>
     <Text>
       Per poder accedir a la votació, us demanarem el vostre número de DNI (Document Nacional d'Identitat) i data de

--- a/src/elements/Home/Berga.tsx
+++ b/src/elements/Home/Berga.tsx
@@ -4,7 +4,7 @@ import { Link as ReactRouterLink } from 'react-router-dom'
 import VocdoniLogo from '~components/Layout/Logo'
 import bergaImg from '/assets/berga/logo.png'
 
-const votingProcessIds = [];
+const votingProcessIds: string[] = [];
 
 const Berga = () => (
   <Flex flexDirection='column' gap={10} maxW='900px' mx='auto' p={5} minH='100vh'>


### PR DESCRIPTION
> Increased font-size in the "LA VOTACIÓ COMENÇARÀ EL DIJOUS 13 DE FEBRER A LES 9:30" text.

> Hide the voting process links, as they are test process but people entering the page can see it running and think they can vote. It's better to hide them.

We will revert this commit when we have the final processes and it's ready to update to the real voting processes. 

Temporary view: 

![image](https://github.com/user-attachments/assets/c78ef461-f9ef-4d7d-a13f-f6a33bf9abf3)
